### PR TITLE
Support boolean expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,23 @@ Uses code generation to reach better performance.
 var validate = require('validate-scope')(['user:edit'])
 
 // pass an array
-validate(['profile', 'user:edit', 'user:archive']) // returns true
+validate(['profile', 'user:edit']) // returns true
+validate(['profile', 'user:archive']) // returns true
 validate(['profile', 'another-scope']) // returns false
 
 // or a string of scopes separated by whitespaces
 validate('profile user:edit user:archive') // returns true
 
 // or check multiple scopes
-var validate = require('validate-scope')(['user:edit', 'user:archive'])
+var validate = require('validate-scope')('user:edit AND user:archive')
 validate('profile user:edit') // returns false
 validate('profile user:edit user:archive') // returns true
 
+// you can use more complex boolean expressions
+var validate = require('validate-scope')('first && second && !third')
+validate(['first']) // returns false
+validate(['first second']) // returns true
+validate(['first second third']) // returns false
 ```
 
 # Api
@@ -38,15 +44,15 @@ I suggest you to save your scopes as array and also pass that to this validation
 NANOBENCH version 1
 
 # validate("some space separate scopes")
-  end ~4.34 s (4 s + 343145562 ns)
+  end ~3.51 s (3 s + 513290216 ns)
 # validate(["some", "scopes", "as", "array"])
-  end ~743 ms (0 s + 743110911 ns)
+  end ~599 ms (0 s + 598547467 ns)
 # traditional string split & array indexOf
-  end ~11 s (11 s + 198361893 ns)
+  end ~8.58 s (8 s + 583230771 ns)
 # traditional for loop & array indexOf
-  end ~946 ms (0 s + 946043059 ns)
+  end ~694 ms (0 s + 693684995 ns)
 
-# total ~17 s (17 s + 230661425 ns)
+# total ~13 s (13 s + 388753449 ns)
 
 # ok
 ```

--- a/benchmark.js
+++ b/benchmark.js
@@ -53,7 +53,6 @@ bench('traditional for loop & array indexOf', function (b) {
 })
 
 function contains (mandatory, scopes) {
-  if (scopes.length < mandatory.length) return false
   for (var i = 0; i < mandatory.length; i++) {
     if (!~scopes.indexOf(mandatory[i])) return false
   }

--- a/index.js
+++ b/index.js
@@ -1,23 +1,48 @@
 /* eslint-disable no-new-func, no-useless-escape */
-module.exports = function getValidate (mandatory) {
-  if (typeof mandatory === 'string') mandatory = mandatory.split(' ')
+var allOperators = /(!|&&| AND | OR | NOT |\|\||\(|\)| )/g
+module.exports = function getValidate (expression) {
+  if (Array.isArray(expression)) expression = expression.join(' ')
+  if (!/(AND|OR|!|&|\|)/.test(expression)) expression = expression.split(' ').filter(Boolean).join(' && ')
 
-  return new Function(`
-    ${map(mandatory, 'var a:1 = /(?:^|\\\s):0(?:\\\s|$)/').join('\n  ')}
+  var segments = expression.split(allOperators).filter(Boolean)
+  var checkArray = segments.reduce(gen(true).func, []).join(' ')
 
-    return function validate (scopes) {
-      if (typeof scopes === 'string') {
-        ${map(mandatory, 'if (!a:1.test(scopes)) return false').join('\n        ')}
-      } else {
-        ${map(mandatory, 'if (!~scopes.indexOf(":0")) return false').join('\n        ')}
-      }
-      return true
-    }
-  `)()
+  var reducer = gen(false)
+  var checkString = segments.reduce(reducer.func, []).join(' ')
+  var tokens = reducer.tokens.map(toRegExDeclaration).join('\n')
+
+  return new Function([tokens,
+    'return function validate (scopes) {',
+    '  if (typeof scopes === \'string\') return ' + checkString,
+    '  return ' + checkArray,
+    '}'].join('\n'))()
 }
 
-function map (arr, template) {
-  return arr.map(function (el, i) {
-    return template.replace(':0', el).replace(':1', i)
-  })
+var nativeOperators = /^(!|&&|\|\||\(|\))$/
+function gen (checkArray) {
+  var tokens = []
+  return {
+    tokens: tokens,
+    func: function rewrite (r, el, i, all) {
+      var t = el.trim()
+      if (!t) return r
+      if (nativeOperators.test(el)) r.push(el)
+      else if (t === 'OR') r.push('||')
+      else if (t === 'AND') r.push('&&')
+      else if (t === 'NOT') r.push('!')
+      else {
+        r.push(el)
+
+        var token = r[r.length - 1].replace(/['\\]/g, '\\$&')
+        if (checkArray) r[r.length - 1] = '!!~scopes.indexOf(\'' + token + '\')'
+        else r[r.length - 1] = 'a' + (tokens.push(token) - 1) + '.test(scopes)'
+      }
+      return r
+    }
+  }
+}
+
+function toRegExDeclaration (t, i) {
+  t = t.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&')
+  return 'var a:1 = /(?:^|\\\s):0(?:\\\s|$)/'.replace(':0', t).replace(':1', i)
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,5 @@
 var assert = require('assert')
+
 test(false, false)
 test(false, true)
 test(true, false)
@@ -8,7 +9,7 @@ function test (mandatoryAsArray, scopeAsArray) {
   function scopes (mandatory) {
     var mod = require('./index')
     var check
-    if (scopeAsArray) check = mod(mandatory.split(' '))
+    if (mandatoryAsArray) check = mod(mandatory.split(' '))
     else check = mod(mandatory)
 
     return function (val) {
@@ -46,6 +47,52 @@ function test (mandatoryAsArray, scopeAsArray) {
   assert.equal(mandatoryScopeAsString('foobar test qux quz'), false)
   assert.equal(mandatoryScopeAsString('bar test quz'), false)
   assert.equal(mandatoryScopeAsString('foo test bar quz'), true)
+
+  var caseSensitive = scopes('foo')
+  assert.equal(caseSensitive('foo'), true)
+  assert.equal(caseSensitive('FOO'), false)
+  assert.equal(caseSensitive('Foo'), false)
+
+  // Boolean expressions
+  var expression1 = scopes('first && second && !third')
+  assert.equal(expression1('foo'), false)
+  assert.equal(expression1('first'), false)
+  assert.equal(expression1('first second'), true)
+  assert.equal(expression1('first second another'), true)
+  assert.equal(expression1('first second another third'), false)
+
+  var expression2 = scopes('first || second')
+  assert.equal(expression2('foo'), false)
+  assert.equal(expression2('first'), true)
+  assert.equal(expression2('foo second'), true)
+  assert.equal(expression2('first second'), true)
+
+  var expression3 = scopes('!first || (second && third && !fourth)')
+  assert.equal(expression3('foo'), true)
+  assert.equal(expression3('first'), false)
+  assert.equal(expression3('first second'), false)
+  assert.equal(expression3('first second third'), true)
+  assert.equal(expression3('second third'), true)
+  assert.equal(expression3('first second third foo fourth'), false)
+
+  var expression4 = scopes('NOT first AND second')
+  assert.equal(expression4('foo'), false)
+  assert.equal(expression4('first'), false)
+  assert.equal(expression4('foo first'), false)
+  assert.equal(expression4('second'), true)
+  assert.equal(expression4('second third'), true)
+
+  var expression5 = scopes('NOT (first AND second)')
+  assert.equal(expression5('foo'), true)
+  assert.equal(expression5('first'), true)
+  assert.equal(expression5('second'), true)
+  assert.equal(expression5('first second'), false)
+  assert.equal(expression5('first second foo'), false)
+
+  var ORkeyword = scopes('first OR second')
+  assert.equal(ORkeyword('foo bar'), false)
+  assert.equal(ORkeyword('first foo bar'), true)
+  assert.equal(ORkeyword('second foo bar'), true)
 
   var m = mandatoryAsArray ? 'array' : 'string'
   var s = scopeAsArray ? 'array' : 'string'


### PR DESCRIPTION
```js
  // Boolean expressions
  var expression1 = scopes('first && second && !third')
  assert.equal(expression1('foo'), false)
  assert.equal(expression1('first'), false)
  assert.equal(expression1('first second'), true)
  assert.equal(expression1('first second another'), true)
  assert.equal(expression1('first second another third'), false)

  var expression2 = scopes('first || second')
  assert.equal(expression2('foo'), false)
  assert.equal(expression2('first'), true)
  assert.equal(expression2('foo second'), true)
  assert.equal(expression2('first second'), true)

  var expression3 = scopes('!first || (second && third && !fourth)')
  assert.equal(expression3('foo'), true)
  assert.equal(expression3('first'), false)
  assert.equal(expression3('first second'), false)
  assert.equal(expression3('first second third'), true)
  assert.equal(expression3('second third'), true)
  assert.equal(expression3('first second third foo fourth'), false)

  var expression4 = scopes('NOT first AND second')
  assert.equal(expression4('foo'), false)
  assert.equal(expression4('first'), false)
  assert.equal(expression4('foo first'), false)
  assert.equal(expression4('second'), true)
  assert.equal(expression4('second third'), true)

  var expression5 = scopes('NOT (first AND second)')
  assert.equal(expression5('foo'), true)
  assert.equal(expression5('first'), true)
  assert.equal(expression5('second'), true)
  assert.equal(expression5('first second'), false)
  assert.equal(expression5('first second foo'), false)

  var ORkeyword = scopes('first OR second')
  assert.equal(ORkeyword('foo bar'), false)
  assert.equal(ORkeyword('first foo bar'), true)
  assert.equal(ORkeyword('second foo bar'), true)
```